### PR TITLE
Fix failure to produce detailed error when parsing xml failed on chrome.

### DIFF
--- a/ample/runtime/browser.js
+++ b/ample/runtime/browser.js
@@ -1102,6 +1102,12 @@ function fBrowser_processScripts() {
 													oDocument.parseError.srcText + '\n' +
 													new cArray(oDocument.parseError.linepos).join('-') + '^';
 			    }
+                //Unknown failure on our part (No Document or Document ParserError).
+                else {
+					oElementNew.innerText	= 'XML Parsing Error: ' + 'Unknown failure to parse.' + '\n' +
+													'Location: ' + (oUALocation) + '\n';
+                    oElementNew.innerText	+= 'Document ' + (oDocument?'exists':'does not exist'); 
+                }
 //<-Debug
 
 //->Debug

--- a/ample/runtime/browser.js
+++ b/ample/runtime/browser.js
@@ -1104,7 +1104,7 @@ function fBrowser_processScripts() {
 			    }
                 //Unknown failure on our part (No Document or Document ParserError).
                 else {
-					oElementNew.innerText	= 'XML Parsing Error: ' + 'Unknown failure to parse.' + '\n' +
+					oElementNew.innerText	= 'XML Parsing Error: ' + 'Unknown failure to parse.  This should not happen.  It means that the browser did not return a parsing error we understand.' + '\n' +
 													'Location: ' + (oUALocation) + '\n';
                     oElementNew.innerText	+= 'Document ' + (oDocument?'exists':'does not exist'); 
                 }

--- a/ample/runtime/browser.js
+++ b/ample/runtime/browser.js
@@ -14,6 +14,7 @@ var oBrowser_factory	= oUADocument.createElement("span"),
 	oBrowser_body		= null,
 	hBrowser_keyIdentifiers	= fUtilities_stringToHash("8:Backspace;9:Tab;13:Enter;16:Shift;17:Control;18:Alt;20:CapsLock;27:Esc;33:PageUp;34:PageDown;35:End;36:Home;37:Left;38:Up;39:Right;40:Down;45:Insert;46:Backspace;91:Win;112:F1;113:F2;114:F3;115:F4;116:F5;117:F6;118:F7;119:F8;120:F9;121:F10;122:F11;123:F12;127:Del"),
 	hBrowser_cssColors		= fUtilities_stringToHash("aliceblue:F0F8FF;antiquewhite:FAEBD7;aqua:00FFFF;aquamarine:7FFFD4;azure:F0FFFF;beige:F5F5DC;bisque:FFE4C4;black:000000;blanchedalmond:FFEBCD;blue:0000FF;blueviolet:8A2BE2;brown:A52A2A;burlywood:DEB887;cadetblue:5F9EA0;chartreuse:7FFF00;chocolate:D2691E;coral:FF7F50;cornflowerblue:6495ED;cornsilk:FFF8DC;crimson:DC143C;cyan:00FFFF;darkblue:00008B;darkcyan:008B8B;darkgoldenrod:B8860B;darkgray:A9A9A9;darkgreen:006400;darkkhaki:BDB76B;darkmagenta:8B008B;darkolivegreen:556B2F;darkorange:FF8C00;darkorchid:9932CC;darkred:8B0000;darksalmon:E9967A;darkseagreen:8FBC8F;darkslateblue:483D8B;darkslategray:2F4F4F;darkturquoise:00CED1;darkviolet:9400D3;deeppink:FF1493;deepskyblue:00BFFF;dimgray:696969;dodgerblue:1E90FF;firebrick:B22222;floralwhite:FFFAF0;forestgreen:228B22;fuchsia:FF00FF;gainsboro:DCDCDC;ghostwhite:F8F8FF;gold:FFD700;goldenrod:DAA520;gray:808080;green:008000;greenyellow:ADFF2F;honeydew:F0FFF0;hotpink:FF69B4;indianred:CD5C5C;indigo:4B0082;ivory:FFFFF0;khaki:F0E68C;lavender:E6E6FA;lavenderblush:FFF0F5;lawngreen:7CFC00;lemonchiffon:FFFACD;lightblue:ADD8E6;lightcoral:F08080;lightcyan:E0FFFF;lightgoldenrodyellow:FAFAD2;lightgreen:90EE90;lightgrey:D3D3D3;lightpink:FFB6C1;lightsalmon:FFA07A;lightseagreen:20B2AA;lightskyblue:87CEFA;lightslategray:778899;lightsteelblue:B0C4DE;lightyellow:FFFFE0;lime:00FF00;limegreen:32CD32;linen:FAF0E6;magenta:FF00FF;maroon:800000;mediumaquamarine:66CDAA;mediumblue:0000CD;mediumorchid:BA55D3;mediumpurple:9370DB;mediumseagreen:3CB371;mediumslateblue:7B68EE;mediumspringgreen:00FA9A;mediumturquoise:48D1CC;mediumvioletred:C71585;midnightblue:191970;mintcream:F5FFFA;mistyrose:FFE4E1;moccasin:FFE4B5;navajowhite:FFDEAD;navy:000080;oldlace:FDF5E6;olive:808000;olivedrab:6B8E23;orange:FFA500;orangered:FF4500;orchid:DA70D6;palegoldenrod:EEE8AA;palegreen:98FB98;paleturquoise:AFEEEE;palevioletred:DB7093;papayawhip:FFEFD5;peachpuff:FFDAB9;peru:CD853F;pink:FFC0CB;plum:DDA0DD;powderblue:B0E0E6;purple:800080;red:FF0000;rosybrown:BC8F8F;royalblue:4169E1;saddlebrown:8B4513;salmon:FA8072;sandybrown:F4A460;seagreen:2E8B57;seashell:FFF5EE;sienna:A0522D;silver:C0C0C0;skyblue:87CEEB;slateblue:6A5ACD;slategray:708090;snow:FFFAFA;springgreen:00FF7F;steelblue:4682B4;tan:D2B48C;teal:008080;thistle:D8BFD8;tomato:FF6347;turquoise:40E0D0;violet:EE82EE;wheat:F5DEB3;white:FFFFFF;whitesmoke:F5F5F5;yellow:FFFF00;yellowgreen:9ACD32", '#'),
+    hBrowser_entities   = {},
 	aBrowser_mouseNodes	= new cNodeList,
 	oBrowser_mouseNode	= null,
 	oBrowser_captureNode= null,		// Set in Capture manager
@@ -761,8 +762,46 @@ function fBrowser_parseXML(sText) {
 	// Bugfix FF4 (remote XUL)
 	if (bGecko)
 		sText	= sText.replace(new cRegExp(sNS_XUL, 'g'), sNS_XUL + '#');
+    //TODO: Parse DocTypes and DTDs properly.
+    //HACK START: To make translations work properly by processing DocTypes and entities in DTDs.
+    fBrowser_parseDoctypes(sText);
+    sText = fBrowser_parseEntities(sText);
+    //HACK END
 	return new cDOMParser().parseFromString(sText, "text/xml");
 };
+
+//HACK START: To make translations work properly by processing DocTypes and entities in DTDs.
+function fBrowser_parseEntities(sText) {
+    for (var sEntityName in hBrowser_entities) {
+		sText	= sText.replace(new cRegExp('&' + sEntityName + ';', 'g'), hBrowser_entities[sEntityName]);        
+    }
+    return sText;
+}
+
+function fBrowser_parseDoctypes(sText) {
+    // For each DOCTYPE clause
+    var aMatchDocType, oDocTypePattern = /<!DOCTYPE\s+(\S+)(\s+(SYSTEM|PUBLIC))?(\s+"(.+)")?(\s+\[([^\]]+)\])?\s*>/img;
+
+    while (result = oDocTypePattern.exec(sText)) {
+        if (result[3] == 'SYSTEM' && result[5]) {
+            //External DTD by URL
+            var oRequest = fBrowser_load(result[5],'application/xml-dtd');
+            fBrowser_parseDTD(oRequest.sText);
+        }
+        if (result[7])
+            fBrowser_parseDTD(result[7]);
+    }
+
+};
+
+function fBrowser_parseDTD(sText) {
+    // Process entities in DTDs
+    var aMatchEntity, oEntityPattern = /<!ENTITY\s+(\S+)\s+("([^"]*)"|'([^']*)')\s*>/img;
+    while (aMatchEntity = oEntityPattern.exec(result[7])) {
+        hBrowser_entities[aMatchEntity[1]] = aMatchEntity[3];
+    }
+}
+//HACK END
 
 function fBrowser_getResponseDocument(oRequest) {
 	var oDocument	= oRequest.responseXML,
@@ -781,7 +820,13 @@ function fBrowser_getResponseDocument(oRequest) {
 			oDocument	= fBrowser_parseXML(sText);
 	}
 	// Check if there is no error in document
-	if (!oDocument || ((bTrident && nVersion < 9 && oDocument.parseError != 0) || !oDocument.documentElement || oDocument.getElementsByTagName("parsererror").length <= 0))
+	if (!oDocument)
+		return null;
+    if (bTrident && nVersion < 9 && oDocument.parseError != 0)
+		return null;
+    if (!oDocument.documentElement)
+		return null;
+    if (oDocument.getElementsByTagName("parsererror").length > 0)
 		return null;
 	return oDocument;
 };

--- a/ample/runtime/browser.js
+++ b/ample/runtime/browser.js
@@ -776,9 +776,12 @@ function fBrowser_getResponseDocument(oRequest) {
 		// Bugfix FF4 (remote XUL)
 		if (bGecko)
 			oDocument	= fBrowser_parseXML(sText);
+
+		if (bWebKit && !oDocument)
+			oDocument	= fBrowser_parseXML(sText);
 	}
 	// Check if there is no error in document
-	if (!oDocument || ((bTrident && nVersion < 9 && oDocument.parseError != 0) || !oDocument.documentElement || oDocument.getElementsByTagName("parsererror").length))
+	if (!oDocument || ((bTrident && nVersion < 9 && oDocument.parseError != 0) || !oDocument.documentElement || oDocument.getElementsByTagName("parsererror").length <= 0))
 		return null;
 	return oDocument;
 };
@@ -1109,11 +1112,11 @@ function fBrowser_processScripts() {
 		else
 		if (sType == "application/ample+javascript" || sType == "text/ample+javascript") {
 			if (sSrc)
-				sText	= fBrowser_load(sSrc, "text/javascript");
+				oRequest	= fBrowser_load(sSrc, "text/javascript");
 
 			// Try executing
 			try {
-				fBrowser_eval(sText);
+				fBrowser_eval(oRequest.responseText);
 			} catch (oException) {
 //->Debug
 				fUtilities_warn(sGUARD_JAVASCRIPT_SYNTAX_WRN, [oException.message]);


### PR DESCRIPTION
If the DOMParser fails to parse the XML in chrome, oDocument becomes null resulting in a lack of opportunity for fBrowser_processScripts() to access the parser error details.

This patch fixes this oversight by forcing the sText through the parser in WebKit, which results in a Document, which can then be returned.

Additionally, a type error to do with the length of the parsererror element is also part of this patch.
