### PR TITLE
$getContainer() returns null after adding own id attributes

### DIFF
--- a/ample/runtime/classes/core/Element.js
+++ b/ample/runtime/classes/core/Element.js
@@ -824,6 +824,12 @@ function fElement_getContainerTraverse(oNode, rClass) {
 
 cElement.prototype.$getContainer	= function(sName) {
 	var oElement	= oUADocument.getElementById(fElement_getAttribute(this, 'id') || this.uniqueID);
+
+	// when called from fElement_mapAttribute (line 273) after an id attribute has been added, this
+	// id has not been propagated to the view document before, so we need to search for the uniqueID
+	// once more.
+	if (!oElement) oElement = oUADocument.getElementById(this.uniqueID);
+	
 	if (sName && oElement)
 		oElement	= fElement_getContainerTraverse(oElement, new cRegExp('--' + sName + '(\\s|$)'));
 	return oElement;

--- a/ample/runtime/classes/core/Element.js
+++ b/ample/runtime/classes/core/Element.js
@@ -824,12 +824,7 @@ function fElement_getContainerTraverse(oNode, rClass) {
 
 cElement.prototype.$getContainer	= function(sName) {
 	var oElement	= oUADocument.getElementById(fElement_getAttribute(this, 'id') || this.uniqueID);
-
-	// when called from fElement_mapAttribute (line 273) after an id attribute has been added, this
-	// id has not been propagated to the view document before, so we need to search for the uniqueID
-	// once more.
 	if (!oElement) oElement = oUADocument.getElementById(this.uniqueID);
-	
 	if (sName && oElement)
 		oElement	= fElement_getContainerTraverse(oElement, new cRegExp('--' + sName + '(\\s|$)'));
 	return oElement;


### PR DESCRIPTION
When you create UI elements (e. g. xul:listitem) programatically and give them an id attribute, you get an Exception "TypeError: this.$getContainer(...) is null" on attempting to add xul:listcell children.

This is because the new id has not been propagated to the shadow tree yet, but fElement_mapAttribute calls $getContainer, which searches for this id there.
